### PR TITLE
Bugfix for change that eliminated initializing gdnativeLibraryRef

### DIFF
--- a/src/Godot/Gdnative/Internal/Gdnative.chs
+++ b/src/Godot/Gdnative/Internal/Gdnative.chs
@@ -823,7 +823,7 @@ gdnativeCore11ApiStructRef = unsafePerformIO $ newIORef $
 
 gdnativeLibraryRef :: IORef Object
 gdnativeLibraryRef = unsafePerformIO $ newIORef $ 
-  error "attempted to get gdnativeCoreApiStructRef too early"
+  error "attempted to get gdnativeLibraryRef too early"
 {-# NOINLINE gdnativeLibraryRef #-}
 
 gdnativeCore12ApiStructRef :: IORef GdnativeCore12ApiStruct
@@ -870,6 +870,7 @@ initApiStructs :: GdnativeInitOptions -> IO ()
 initApiStructs opts = do
   let coreApi = gdnativeInitOptionsApiStruct opts
   writeIORef gdnativeCoreApiStructRef coreApi
+  writeIORef gdnativeLibraryRef $ gdnativeInitOptionsGdNativeLibrary opts
 
   findExt GdnativeCore11ApiStruct gdnativeCore11ApiStructRef (coerce coreApi) 1 1
   findExt GdnativeCore12ApiStruct gdnativeCore12ApiStructRef (coerce coreApi) 1 2


### PR DESCRIPTION
A change eliminated the initialization of gdnativeLibraryRef.
This is pretty fatal and leads to errors on signals.